### PR TITLE
feat: add webhook request error logging

### DIFF
--- a/cmd/datum-authorization-webhook/app/internal/iam/core_control_plane_authorizer.go
+++ b/cmd/datum-authorization-webhook/app/internal/iam/core_control_plane_authorizer.go
@@ -24,9 +24,10 @@ type CoreControlPlaneAuthorizer struct {
 
 // Authorize implements authorizer.Authorizer.
 func (o *CoreControlPlaneAuthorizer) Authorize(ctx context.Context, attributes authorizer.Attributes) (authorizer.Decision, string, error) {
-	ctx, span := otel.Tracer("go.datum.net/k8s-authz-webhook").Start(ctx, "datum.k8s-authz-webhook.global.Authorize", trace.WithAttributes(
+	ctx, span := otel.Tracer("go.datum.net/k8s-authz-webhook").Start(ctx, "datum.core-control-plane.Authorize", trace.WithAttributes(
 		attribute.String("api_group", attributes.GetAPIGroup()),
 		attribute.String("resource_kind", attributes.GetResource()),
+		attribute.String("subject", attributes.GetUser().GetName()),
 	))
 	defer span.End()
 

--- a/cmd/datum-authorization-webhook/app/internal/webhook/http.go
+++ b/cmd/datum-authorization-webhook/app/internal/webhook/http.go
@@ -114,6 +114,15 @@ func (wh *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	reviewResponse = wh.Handle(ctx, req)
+	if reviewResponse.Status.EvaluationError != "" {
+		span.RecordError(errors.New(reviewResponse.Status.EvaluationError))
+		span.SetStatus(codes.Error, reviewResponse.Status.EvaluationError)
+	}
+
+	span.SetAttributes(
+		attribute.Bool("denied", reviewResponse.Status.Denied),
+		attribute.Bool("allowed", reviewResponse.Status.Allowed),
+	)
 
 	slog.InfoContext(
 		ctx,

--- a/cmd/datum-authorization-webhook/app/internal/webhook/webhook.go
+++ b/cmd/datum-authorization-webhook/app/internal/webhook/webhook.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 
 	authorizationv1 "k8s.io/api/authorization/v1"
@@ -55,6 +56,7 @@ func NewAuthorizerWebhook(authzer authorizer.Authorizer) *Webhook {
 				attrs,
 			)
 			if err != nil {
+				slog.ErrorContext(ctx, "error authorizing request", slog.String("error", err.Error()))
 				return Errored(err)
 			}
 

--- a/cmd/datum-authorization-webhook/app/webhook.go
+++ b/cmd/datum-authorization-webhook/app/webhook.go
@@ -1,16 +1,33 @@
 package app
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/spf13/cobra"
+	"go.datumapis.com/datum/pkg/cmd"
+)
 
 func NewWebhook() *cobra.Command {
-	cmd := &cobra.Command{
+	webhook := &cobra.Command{
 		Use:   "datum-authorization-webhook",
 		Short: "An authorization webhook backed by the Datum IAM service",
+		PersistentPreRunE: func(webhook *cobra.Command, args []string) error {
+			logger, err := cmd.SetupLogging(webhook)
+			if err != nil {
+				return fmt.Errorf("failed to configure logging: %w", err)
+			}
+
+			slog.SetDefault(logger)
+			return nil
+		},
 	}
 
-	cmd.AddCommand(
+	cmd.AddLoggingFlags(webhook.PersistentFlags())
+
+	webhook.AddCommand(
 		serveCommand(),
 	)
 
-	return cmd
+	return webhook
 }

--- a/pkg/cmd/logging.go
+++ b/pkg/cmd/logging.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func AddLoggingFlags(cmd *pflag.FlagSet) {
+
+	cmd.String("log-level", "INFO", "The level of logs that should be emitted from the service. Supports: 'ERROR', 'WARN', 'INFO', 'DEBUG'")
+	cmd.String("log-format", "json", "The format of logs that should be emitted from the service. Supports: 'json' and 'text'")
+}
+
+func SetupLogging(cmd *cobra.Command) (*slog.Logger, error) {
+	level, err := cmd.Flags().GetString("log-level")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get `--log-level` flag: %w", err)
+	}
+
+	format, err := cmd.Flags().GetString("log-format")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get `--log-format` flag: %w", err)
+	}
+
+	var handler slog.Handler
+
+	handlerOpts := &slog.HandlerOptions{
+		AddSource: true,
+	}
+
+	switch level {
+	case "ERROR":
+		handlerOpts.Level = slog.LevelError
+	case "WARN":
+		handlerOpts.Level = slog.LevelWarn
+	case "INFO":
+		handlerOpts.Level = slog.LevelInfo
+	case "DEBUG":
+		handlerOpts.Level = slog.LevelDebug
+	default:
+		return nil, fmt.Errorf("log level '%s' is invalid. Supported options are: 'ERROR', 'WARN', 'INFO', 'DEBUG'", level)
+	}
+
+	switch format {
+	case "json":
+		handler = slog.NewJSONHandler(os.Stderr, handlerOpts)
+	case "text":
+		handler = slog.NewTextHandler(os.Stderr, handlerOpts)
+	default:
+		return nil, fmt.Errorf("log format '%s' is invalid. Supported options are 'json', 'text'", format)
+	}
+
+	return slog.New(handler), nil
+}


### PR DESCRIPTION
Adds new error logs to the webhook request handler so it's easier to determine issues with the webhook. Documents the errors on the traces as well.

Also adds new flags to control logging levels and formats of the webhook. Added the utility as a package so it could be re-used across CLIs.