### PR TITLE
chore: build on release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+  release:
+    types: ["published"]
 
 jobs:
   build-and-push:


### PR DESCRIPTION
Configures the build workflow to execute when releases are published.