### PR TITLE
Fix webhook internal error

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,37 @@
+name: Go Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    name: Run Go Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Install dependencies
+        run: go mod tidy
+
+      - name: Run Tests
+        run: go test -v ./...

--- a/cmd/datum-authorization-webhook/app/internal/webhook/http.go
+++ b/cmd/datum-authorization-webhook/app/internal/webhook/http.go
@@ -110,6 +110,9 @@ func (wh *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if projectID := r.PathValue("project"); projectID != "" {
 		projectName := "projects/" + projectID
 		span.SetAttributes(attribute.String("project", projectName))
+		if req.Spec.Extra == nil {
+			req.Spec.Extra = map[string]authorizationv1.ExtraValue{}
+		}
 		req.Spec.Extra[ProjectExtraKey] = []string{projectName}
 	}
 

--- a/cmd/datum-authorization-webhook/app/internal/webhook/webhook_test.go
+++ b/cmd/datum-authorization-webhook/app/internal/webhook/webhook_test.go
@@ -1,0 +1,123 @@
+package webhook_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"go.datumapis.com/datum/cmd/datum-authorization-webhook/app/internal/webhook"
+	v1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+func TestWebhook(t *testing.T) {
+	mux := http.NewServeMux()
+	// Register the project specific webhook mux
+	mux.Handle("/project/v1alpha/projects/{project}/webhook", webhook.NewAuthorizerWebhook(authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+		return authorizer.DecisionAllow, "", nil
+	})))
+
+	srv := &http.Server{
+		Addr:    "127.0.0.1:11000",
+		Handler: mux,
+	}
+
+	go func() {
+		err := srv.ListenAndServe()
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			t.Errorf("failed to start webhook server: %s", err)
+		}
+	}()
+
+	defer srv.Shutdown(context.Background())
+
+	client := &http.Client{}
+
+	// Define test cases to execute against the webhook
+	testCases := []struct {
+		desc               string
+		url                url.URL
+		request            webhook.Request
+		expectedResponse   webhook.Response
+		expectedStatusCode int
+	}{
+		{
+			desc: "Validate server returns correct authorization response when extra data is empty",
+			url: url.URL{
+				Path: "/project/v1alpha/projects/my-personal-project/webhook",
+			},
+			request: webhook.Request{
+				SubjectAccessReview: v1.SubjectAccessReview{
+					Spec: v1.SubjectAccessReviewSpec{
+						User: "user:test-user@datum.net",
+						UID:  "525c3cc0-6960-4950-8999-f50af1bc050d",
+						ResourceAttributes: &v1.ResourceAttributes{
+							Namespace: "default",
+							Verb:      "use",
+							Group:     "networking.datumapis.com",
+							Version:   "v1alpha",
+							Resource:  "networks",
+							Name:      "default",
+						},
+					},
+				},
+			},
+			expectedStatusCode: http.StatusOK,
+			expectedResponse: webhook.Response{
+				SubjectAccessReview: v1.SubjectAccessReview{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "SubjectAccessReview",
+						APIVersion: "authorization.k8s.io/v1",
+					},
+					Status: v1.SubjectAccessReviewStatus{
+						Allowed: true,
+						Denied:  false,
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		// Configure to what the server is listening on
+		testCase.url.Host = "localhost:11000"
+		testCase.url.Scheme = "http"
+
+		t.Run(testCase.desc, func(t *testing.T) {
+			body, err := json.Marshal(testCase.request)
+			if err != nil {
+				t.Errorf("failed to marshall authorization request: %s", err)
+				return
+			}
+
+			resp, err := client.Post(testCase.url.String(), "application/json", strings.NewReader(string(body)))
+			if err != nil {
+				t.Errorf("failed to call webhook endpoint: %s", err)
+				return
+			}
+
+			if resp.StatusCode != testCase.expectedStatusCode {
+				t.Errorf("got status code %d but expected %d", resp.StatusCode, &testCase.expectedStatusCode)
+				return
+			}
+
+			webhookResponse := webhook.Response{}
+			decoder := json.NewDecoder(resp.Body)
+			if err := decoder.Decode(&webhookResponse); err != nil {
+				t.Errorf("failed to decode webhook response: %s", err)
+				return
+			}
+
+			if !cmp.Equal(webhookResponse, testCase.expectedResponse) {
+				t.Error("webhook response did not match expected response, see logs for details")
+				t.Log("response diff: ", cmp.Diff(webhookResponse, testCase.expectedResponse))
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/google/gnostic-models v0.6.8/go.mod h1:5n7qKqH0f5wFt+aWF8CW6pZLLNOfYu
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=


### PR DESCRIPTION
Fixes an issue where the webhook would panic when the `Extra` data wasn't being set in the authorization request. The Kubernetes API server will always provide the Extra map when performing authorization requests, so most authorization requests were successfully executed. The [SubjectAuthorizationReview created by the workload operator](https://github.com/datum-cloud/workload-operator/blob/24c6f0ae8712b4b049b6d838646f2d7388c032e7/internal/validation/instance_validation.go#L100-L114) to validate a customer has access to use a network isn't setting the Extra map causing that authorization check to fail.

This also introduces end-to-end testing that validates the webhook returns the correct response when the Extra data isn't being set in the request and configures a GitHub action to confirm tests are passing.