### PR TITLE
Settings to have containers as an explicit list for patching purposes

### DIFF
--- a/config/apiserver/deployment.yaml
+++ b/config/apiserver/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       automountServiceAccountToken: false
       containers:
-        image: us-east4-docker.pkg.dev/datum-cloud-prod/datum-internal-images/datum-apiserver:v0.0.1-v1alpha12-amd64
+      - image: us-east4-docker.pkg.dev/datum-cloud-prod/datum-internal-images/datum-apiserver:v0.0.1-v1alpha12-amd64
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
The goal is to convert **containers** into an explicit list so that we can navigate to this attribute using kustomize patches.