### PR TITLE
chore: create policy binding for admission policy

### DIFF
--- a/config/policies/validation/organization-update-policy.yaml
+++ b/config/policies/validation/organization-update-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
-  name: "organization-update-policy.miloapis.com"
+  name: "disallow-personal-org-name-change"
 spec:
   failurePolicy: Fail
   matchConstraints:
@@ -13,3 +13,11 @@ spec:
   validations:
   - expression: "object.spec.type != 'Personal' || oldObject.metadata.annotations['kubernetes.io/display-name'] == object.metadata.annotations['kubernetes.io/display-name']"
     message: "The display name of a personal organization cannot be changed."
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "disallow-personal-org-name-change"
+spec:
+  policyName: "disallow-personal-org-name-change"
+  validationActions: [Deny]


### PR DESCRIPTION
Creates a policy binding to enable the validating admission policy in the control plane. 