### PR TITLE
bugfix: publish container images on release

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
   pull_request:
+  release:
+    types:
+      - published
 
 jobs:
   publish-container-image:


### PR DESCRIPTION
Run the build and test workflow when a release is published.