### PR TITLE
feat: include email templates in kustomization configuration

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
 - ../rbac
 - ../manager
 - ../policies
+- ../email-templates
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook


### PR DESCRIPTION
Added the email-templates resource to the kustomization.yaml file to ensure the email invitation templates are included in the deployment configuration.