### PR TITLE
chore: remove policies from default kustomization

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -18,7 +18,6 @@ resources:
 #- ../crd
 - ../rbac
 - ../manager
-- ../policies
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook


### PR DESCRIPTION
These policy configurations are expected to be created in Milo's API and not the infrastructure API where this kustomization is deployed to.