### PR TITLE
Add viewer role and role binding for assignable organization roles

### DIFF
--- a/config/assignable-organization-roles/bindings/viewer-role-binding.yaml
+++ b/config/assignable-organization-roles/bindings/viewer-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: assignable-organization-roles-viewer-binding
+  namespace: datum-cloud
+subjects:
+  - kind: Group
+    name: system:authenticated
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: assignable-organization-roles-viewer

--- a/config/assignable-organization-roles/kustomization.yaml
+++ b/config/assignable-organization-roles/kustomization.yaml
@@ -1,6 +1,8 @@
 namespace: datum-cloud
 resources:
   - namespace.yaml
+  - roles/viewer-role.yaml
+  - bindings/viewer-role-binding.yaml
   # IAM roles
   - https://raw.githubusercontent.com/datum-cloud/milo/refs/tags/v0.5.2/config/roles/iam-viewer.yaml
   - https://raw.githubusercontent.com/datum-cloud/milo/refs/tags/v0.5.2/config/roles/iam-editor.yaml

--- a/config/assignable-organization-roles/roles/viewer-role.yaml
+++ b/config/assignable-organization-roles/roles/viewer-role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: assignable-organization-roles-viewer
+  namespace: datum-cloud
+rules:
+- apiGroups: ["iam.miloapis.com"]
+  resources: ["roles"]
+  verbs: ["get", "watch", "list"]


### PR DESCRIPTION
This PR introduces the necessary RBAC roles and role bindings so that authenticated system users can `get/watch/list` the assignable organization roles.