### PR TITLE
feat: use explicit ordering for quota configs

### DIFF
--- a/config/services/resourcemanager.miloapis.com/quota/kustomization.yaml
+++ b/config/services/resourcemanager.miloapis.com/quota/kustomization.yaml
@@ -1,6 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
+# Use explicit sorting options so we can guarantee that resource registrations
+# are applied before grant / claim creation policies that reference the
+# resources being created.
+sortOptions:
+  order: fifo
+
 components:
   - registrations/
   - grant-policies/


### PR DESCRIPTION
This adjusts the ordering policy for the quota configurations to use explicit ordering to ensure resource registrations are applied before the policies are created.