### PR TITLE
chore: add sort options to all service configurations

### DIFF
--- a/config/services/kustomization.yaml
+++ b/config/services/kustomization.yaml
@@ -3,5 +3,10 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
+# Use explicit sorting options so we can guarantee order in which resources are
+# applied.
+sortOptions:
+  order: fifo
+
 components:
   - resourcemanager.miloapis.com/

--- a/config/services/resourcemanager.miloapis.com/kustomization.yaml
+++ b/config/services/resourcemanager.miloapis.com/kustomization.yaml
@@ -9,6 +9,11 @@ components:
   - quota/
   - validation/
 
+# Use explicit sorting options so we can guarantee order in which resources are
+# applied.
+sortOptions:
+  order: fifo
+
 labels:
   - includeSelectors: true
     pairs:

--- a/config/services/resourcemanager.miloapis.com/quota/claim-policies/kustomization.yaml
+++ b/config/services/resourcemanager.miloapis.com/quota/claim-policies/kustomization.yaml
@@ -1,5 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
+# Use explicit sorting options so we can guarantee order in which resources are
+# applied.
+sortOptions:
+  order: fifo
+
 resources:
   - claim-creation-policy.yaml

--- a/config/services/resourcemanager.miloapis.com/quota/grant-policies/kustomization.yaml
+++ b/config/services/resourcemanager.miloapis.com/quota/grant-policies/kustomization.yaml
@@ -1,6 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
+# Use explicit sorting options so we can guarantee order in which resources are
+# applied.
+sortOptions:
+  order: fifo
+
 resources:
   - personal-org-grant-policy.yaml
   - standard-org-grant-policy.yaml

--- a/config/services/resourcemanager.miloapis.com/quota/registrations/kustomization.yaml
+++ b/config/services/resourcemanager.miloapis.com/quota/registrations/kustomization.yaml
@@ -1,5 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
+# Use explicit sorting options so we can guarantee order in which resources are
+# applied.
+sortOptions:
+  order: fifo
+
 resources:
   - project-registration.yaml


### PR DESCRIPTION
Confirmed this time that building the kustomization respects the ordering needed. 

```yaml
▶ kustomize build config/services | head -n 20
apiVersion: quota.miloapis.com/v1alpha1
kind: ResourceRegistration
metadata:
  labels:
    app.kubernetes.io/component: resource-manager-miloapis-com
    app.kubernetes.io/name: datum
    app.kubernetes.io/part-of: datum-cloud
  name: projects-per-organization
spec:
  baseUnit: project
  claimingResources:
  - apiGroup: resourcemanager.miloapis.com
    kind: Project
  consumerType:
    apiGroup: resourcemanager.miloapis.com
    kind: Organization
  description: Maximum number of projects that can be created within an organization
  displayUnit: projects
  resourceType: resourcemanager.miloapis.com/projects
  type: Entity
```