### PR TITLE
chore: Update assignable roles list

### DIFF
--- a/config/assignable-organization-roles/kustomization.yaml
+++ b/config/assignable-organization-roles/kustomization.yaml
@@ -32,15 +32,4 @@ resources:
   - https://raw.githubusercontent.com/datum-cloud/milo/refs/tags/v0.7.5/config/roles/organizationmembership-admin.yaml
   # Indirect roles required by organization-reader
   - https://raw.githubusercontent.com/datum-cloud/milo/refs/tags/v0.7.5/config/roles/organizationmembership-reader.yaml
-  # Indirect roles required by datum-cloud-viewer
-  - https://raw.githubusercontent.com/datum-cloud/milo/refs/tags/v0.7.5/config/roles/resourcemanager-reader.yaml
-  - https://raw.githubusercontent.com/datum-cloud/milo/refs/tags/v0.7.5/config/roles/core-reader.yaml
-  - https://raw.githubusercontent.com/datum-cloud/milo/refs/tags/v0.7.5/config/roles/apiextensions-reader.yaml
-  - https://raw.githubusercontent.com/datum-cloud/milo/refs/tags/v0.7.5/config/services/quota/iam/roles/quota-viewer.yaml
-  # Indirect roles required by datum-cloud-owner
-  - https://raw.githubusercontent.com/datum-cloud/milo/refs/tags/v0.7.5/config/roles/resourcemanager-admin.yaml
-  - https://raw.githubusercontent.com/datum-cloud/milo/refs/tags/v0.7.5/config/roles/resourcemanager-editor.yaml
-  - https://raw.githubusercontent.com/datum-cloud/milo/refs/tags/v0.7.5/config/roles/core-admin.yaml
-  - https://raw.githubusercontent.com/datum-cloud/milo/refs/tags/v0.7.5/config/roles/core-editor.yaml
-  - https://raw.githubusercontent.com/datum-cloud/milo/refs/tags/v0.7.5/config/services/quota/iam/roles/organization-quota-manager.yaml
-  
+

--- a/config/assignable-organization-roles/roles/datum-cloud-owner.yaml
+++ b/config/assignable-organization-roles/roles/datum-cloud-owner.yaml
@@ -9,10 +9,18 @@ spec:
   launchStage: Beta
   inheritedRoles:
     - name: resourcemanager-admin
+      namespace: milo-system
     - name: core-admin
+      namespace: milo-system
     - name: apiextensions-reader
+      namespace: milo-system
     - name: iam-admin
+      namespace: milo-system
     - name: networking.datumapis.com-admin
+      namespace: milo-system
     - name: telemetry.miloapis.com-admin
+      namespace: milo-system
     - name: organizationmembership-reader
+      namespace: milo-system
     - name: quota.miloapis.com-organization-quota-manager
+      namespace: milo-system

--- a/config/assignable-organization-roles/roles/datum-cloud-viewer.yaml
+++ b/config/assignable-organization-roles/roles/datum-cloud-viewer.yaml
@@ -9,10 +9,18 @@ spec:
   launchStage: Beta
   inheritedRoles:
     - name: resourcemanager-reader
+      namespace: milo-system
     - name: core-reader
+      namespace: milo-system
     - name: apiextensions-reader
+      namespace: milo-system
     - name: iam-viewer
+      namespace: milo-system
     - name: networking.datumapis.com-viewer
+      namespace: milo-system
     - name: telemetry.miloapis.com-viewer
+      namespace: milo-system
     - name: organizationmembership-reader
+      namespace: milo-system
     - name: quota.miloapis.com-viewer
+      namespace: milo-system


### PR DESCRIPTION
This PR updates the assumable roles list with the `datum-cloud-owner` and the `datum-cloud-viewer` IAM roles.

It additionally updates Milo IAM roles to the v0.7.5 tag to include the new display-name annotation and description.

More information:
https://datum-inc.slack.com/archives/D084EETRZ8C/p1761581926701319