### PR TITLE
chore: add project name validation

### DIFF
--- a/config/services/resourcemanager.miloapis.com/validation/kustomization.yaml
+++ b/config/services/resourcemanager.miloapis.com/validation/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Component
 
 resources:
   - organization-update-policy.yaml
+  - project-name-validation-policy.yaml

--- a/config/services/resourcemanager.miloapis.com/validation/project-name-validation-policy.yaml
+++ b/config/services/resourcemanager.miloapis.com/validation/project-name-validation-policy.yaml
@@ -1,0 +1,35 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "validate-project-name"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["resourcemanager.miloapis.com"]
+      apiVersions: ["v1alpha1"]
+      operations:  ["CREATE"]
+      resources:   ["projects"]
+  validations:
+  # Minimum name length (6 characters)
+  - expression: "size(object.metadata.name) >= 6"
+    message: "Project name is too short. Project names must be at least 6 characters long. Please choose a longer name."
+    reason: Invalid
+
+  # Maximum name length (30 characters)
+  - expression: "size(object.metadata.name) <= 30"
+    message: "Project name is too long. Project names must not exceed 30 characters. Please choose a shorter name."
+    reason: Invalid
+
+  # Reserved words validation - block names containing "datum"
+  - expression: "!object.metadata.name.contains('datum')"
+    message: "Project name contains the reserved word 'datum' and cannot be used. Please choose a different name."
+    reason: Invalid
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "validate-project-name-binding"
+spec:
+  policyName: "validate-project-name"
+  validationActions: [Deny]


### PR DESCRIPTION
Adds validation to project names to prevent them from containing the keyword `datum`. Adjusts validation to require project names to be between 6 and 30 characters to align with GCP project naming standards. 

We require GCP naming standards because of how our GCP infrastructure provider creates projects in GCP. We can adjust the infra provider in the future.

Confirmed this works as expected:

<img width="374" height="196" alt="image" src="https://github.com/user-attachments/assets/cc977da7-91f2-43e6-ab71-e49c09011f0d" />


Closes: https://github.com/datum-cloud/datum/issues/106