### PR TITLE
feat: dns roles

### DIFF
--- a/config/assignable-organization-roles/kustomization.yaml
+++ b/config/assignable-organization-roles/kustomization.yaml
@@ -167,41 +167,7 @@ patches:
     target:
       kind: Role
       name: networking.datumapis.com-domain-admin
-  - patch: |-
-      - op: add
-        path: /metadata/annotations/taxonomy.miloapis.com~1sort-order
-        value: "110"
-      - op: add
-        path: /metadata/annotations/taxonomy.miloapis.com~1product
-        value: "Configure DNS"
-      - op: add
-        path: /spec/inheritedRoles
-        value:
-          - name: resourcemanager.miloapis.com-organization-viewer
-            namespace: milo-system
-          - name: resourcemanager.miloapis.com-project-viewer
-            namespace: milo-system
-    target:
-      kind: Role
-      name: dns.networking.miloapis.com-dns-viewer
-  - patch: |-
-      - op: add
-        path: /metadata/annotations/taxonomy.miloapis.com~1sort-order
-        value: "112"
-      - op: add
-        path: /metadata/annotations/taxonomy.miloapis.com~1product
-        value: "Configure DNS"
-      - op: add
-        path: /spec/inheritedRoles
-        value:
-          - name: resourcemanager.miloapis.com-organization-viewer
-            namespace: milo-system
-          - name: resourcemanager.miloapis.com-project-viewer
-            namespace: milo-system
-    target:
-      kind: Role
-      name: dns.networking.miloapis.com-dns-admin
-      
+
 resources:
   - namespace.yaml
   # Grant authenticated users access to these roles
@@ -231,7 +197,3 @@ resources:
   - https://raw.githubusercontent.com/datum-cloud/network-services-operator/refs/heads/main/config/iam/roles/domain-admin.yaml
   - https://raw.githubusercontent.com/datum-cloud/network-services-operator/refs/heads/main/config/iam/roles/networking-viewer.yaml
   - https://raw.githubusercontent.com/datum-cloud/network-services-operator/refs/heads/main/config/iam/roles/networking-admin.yaml
-
-  # DNS roles
-  - https://raw.githubusercontent.com/datum-cloud/dns-operator/refs/tags/v0.1.0/config/iam/roles/dns-viewer.yaml
-  - https://raw.githubusercontent.com/datum-cloud/dns-operator/refs/tags/v0.1.0/config/iam/roles/dns-admin.yaml

--- a/config/assignable-organization-roles/roles/datum-cloud-owner.yaml
+++ b/config/assignable-organization-roles/roles/datum-cloud-owner.yaml
@@ -24,7 +24,6 @@ spec:
       namespace: milo-system
     - name: resourcemanager.miloapis.com-project-viewer
       namespace: milo-system
-    - name: dns.networking.miloapis.com-dnszone-admin
+    - name: dns.networking.miloapis.com-dns-admin
       namespace: milo-system
-    - name: dns.networking.miloapis.com-dnsrecordset-admin
-      namespace: milo-system
+      

--- a/config/assignable-organization-roles/roles/datum-cloud-viewer.yaml
+++ b/config/assignable-organization-roles/roles/datum-cloud-viewer.yaml
@@ -22,3 +22,5 @@ spec:
       namespace: milo-system
     - name: resourcemanager.miloapis.com-project-viewer
       namespace: milo-system
+    - name: dns.networking.miloapis.com-dns-viewer
+      namespace: milo-system


### PR DESCRIPTION
This pull request adds new DNS-related roles to the assignable organization roles configuration for the `datum-cloud-owner` and `datum-cloud-viewer` roles, enhancing access control for DNS administration and viewing in the `milo-system` namespace.

Role additions for DNS management:

* Added the `dns.networking.miloapis.com-dns-admin` role to the `datum-cloud-owner` role in the `milo-system` namespace, enabling DNS administration capabilities.
* Added the `dns.networking.miloapis.com-dns-viewer` role to the `datum-cloud-viewer` role in the `milo-system` namespace, allowing DNS viewing access.