### PR TITLE
chore: remove invalid role reference

### DIFF
--- a/config/assignable-organization-roles/roles/datum-cloud-viewer.yaml
+++ b/config/assignable-organization-roles/roles/datum-cloud-viewer.yaml
@@ -10,8 +10,6 @@ metadata:
 spec:
   launchStage: Beta
   inheritedRoles:
-    - name: organization-viewer
-      namespace: datum-cloud
     - name: networking.datumapis.com-viewer
       namespace: milo-system
     - name: telemetry.miloapis.com-viewer


### PR DESCRIPTION
Removes the `organization-viewer` role that was being referenced.