### PR TITLE
fix: add DNS admin to Editor role

### DIFF
--- a/config/assignable-organization-roles/roles/datum-cloud-editor.yaml
+++ b/config/assignable-organization-roles/roles/datum-cloud-editor.yaml
@@ -22,3 +22,5 @@ spec:
       namespace: milo-system
     - name: resourcemanager.miloapis.com-organization-viewer
       namespace: milo-system
+    - name: dns.networking.miloapis.com-dns-admin
+      namespace: milo-system


### PR DESCRIPTION
Resolves #145 by adding the DNS admin role to the Editor role. 