### PR TITLE
feat: grant users access to query audit logs

### DIFF
--- a/config/assignable-organization-roles/roles/datum-cloud-viewer.yaml
+++ b/config/assignable-organization-roles/roles/datum-cloud-viewer.yaml
@@ -24,3 +24,5 @@ spec:
       namespace: milo-system
     - name: iam-user-invitations-reader
       namespace: milo-system
+    - name: activity.miloapis.com-audit-log-querier
+      namespace: milo-system


### PR DESCRIPTION
This PR updates the Datum Cloud Viewer role to allow querying audit log data from the new activity system. See https://github.com/datum-cloud/activity/pull/12 for details. 

---

Relates to https://github.com/datum-cloud/enhancements/issues/536