### PR TITLE
feat: Add Machine Account Roles to assignable roles

### DIFF
--- a/config/assignable-organization-roles/roles/datum-cloud-editor.yaml
+++ b/config/assignable-organization-roles/roles/datum-cloud-editor.yaml
@@ -26,3 +26,7 @@ spec:
       namespace: milo-system
     - name: notes-editor
       namespace: milo-system
+    - name: identity-machine-account-keys-editor
+      namespace: milo-system
+    - name: iam-machine-accounts-editor
+      namespace: milo-system

--- a/config/assignable-organization-roles/roles/datum-cloud-owner.yaml
+++ b/config/assignable-organization-roles/roles/datum-cloud-owner.yaml
@@ -30,3 +30,7 @@ spec:
       namespace: milo-system
     - name: notes-admin
       namespace: milo-system
+    - name: identity-machine-account-keys-admin
+      namespace: milo-system
+    - name: iam-machine-accounts-admin
+      namespace: milo-system

--- a/config/assignable-organization-roles/roles/datum-cloud-viewer.yaml
+++ b/config/assignable-organization-roles/roles/datum-cloud-viewer.yaml
@@ -28,3 +28,7 @@ spec:
       namespace: milo-system
     - name: notes-viewer
       namespace: milo-system
+    - name: identity-machine-account-keys-viewer
+      namespace: milo-system
+    - name: iam-machine-accounts-viewer
+      namespace: milo-system


### PR DESCRIPTION
This PR Grant machine account and key management permissions to cloud assignable roles

Related to:
- https://github.com/datum-cloud/enhancements/issues/129