### PR TITLE
feat: bump default trafficprotectionpolicies quota to 10

### DIFF
--- a/config/services/networking.datumapis.com/quota/grant-policies/default-project-grant-policy.yaml
+++ b/config/services/networking.datumapis.com/quota/grant-policies/default-project-grant-policy.yaml
@@ -35,7 +35,7 @@ spec:
               - amount: 10
           - resourceType: networking.datumapis.com/trafficprotectionpolicies
             buckets:
-              - amount: 0
+              - amount: 10
           - resourceType: networking.datumapis.com/connectors
             buckets:
               - amount: 5


### PR DESCRIPTION
## Summary
- Bumps the default project quota grant for `networking.datumapis.com/trafficprotectionpolicies` from **0** to **10**
- Aligns with other networking resource defaults in the same grant policy

## Test plan
- [ ] Verify new projects receive a quota allowance of 10 for trafficprotectionpolicies