### PR TITLE
fix: add condition to validate metadata.name existence in search reource index policies

### DIFF
--- a/config/services/search.miloapis.com/contact-resourceindexpolicy.yaml
+++ b/config/services/search.miloapis.com/contact-resourceindexpolicy.yaml
@@ -3,6 +3,9 @@ kind: ResourceIndexPolicy
 metadata:
   name: contact-resource-index-policy
 spec:
+  conditions:
+  - expression: has(metadata.name)
+    name: has-name
   fields:
   - path: .metadata.name
     searchable: true

--- a/config/services/search.miloapis.com/dnszone-resourceindexpolicy.yaml
+++ b/config/services/search.miloapis.com/dnszone-resourceindexpolicy.yaml
@@ -3,6 +3,9 @@ kind: ResourceIndexPolicy
 metadata:
   name: dnszone-resource-index-policy
 spec:
+  conditions:
+  - expression: has(metadata.name)
+    name: has-name
   fields:
   - path: .metadata.name
     searchable: true

--- a/config/services/search.miloapis.com/domain-resourceindexpolicy.yaml
+++ b/config/services/search.miloapis.com/domain-resourceindexpolicy.yaml
@@ -3,6 +3,9 @@ kind: ResourceIndexPolicy
 metadata:
   name: domain-resource-index-policy
 spec:
+  conditions:
+  - expression: has(metadata.name)
+    name: has-name
   fields:
   - path: .metadata.name
     searchable: true


### PR DESCRIPTION
This PR resolves an issue where users were not receiving any results when performing a `ResourceSearchQuery` against Domains.

The problem stems from the `ResourceIndexPolicies` not having a valid condition, which resulted in none of the resources having a matching condition for indexing into the search system.

Related to:
- https://discord.com/channels/1420159806496440412/1452783709295214805/1497256197324017777