### PR TITLE
fix: rename machine account references to service accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ We support a growing collection of features that help make agentic and internet 
 - Authoritative DNS
 - Domain resource tracking
 - Fine grained roles and permissions
-- Secrets & machine accounts
+- Secrets & service accounts
 - Activity logs
 
 ## Components

--- a/config/assignable-organization-roles/roles/datum-cloud-editor.yaml
+++ b/config/assignable-organization-roles/roles/datum-cloud-editor.yaml
@@ -26,7 +26,7 @@ spec:
       namespace: milo-system
     - name: notes-editor
       namespace: milo-system
-    - name: identity-machine-account-keys-editor
+    - name: identity-service-account-keys-editor
       namespace: milo-system
-    - name: iam-machine-accounts-editor
+    - name: iam-service-accounts-editor
       namespace: milo-system

--- a/config/assignable-organization-roles/roles/datum-cloud-owner.yaml
+++ b/config/assignable-organization-roles/roles/datum-cloud-owner.yaml
@@ -30,7 +30,7 @@ spec:
       namespace: milo-system
     - name: notes-admin
       namespace: milo-system
-    - name: identity-machine-account-keys-admin
+    - name: identity-service-account-keys-admin
       namespace: milo-system
-    - name: iam-machine-accounts-admin
+    - name: iam-service-accounts-admin
       namespace: milo-system

--- a/config/assignable-organization-roles/roles/datum-cloud-viewer.yaml
+++ b/config/assignable-organization-roles/roles/datum-cloud-viewer.yaml
@@ -28,7 +28,7 @@ spec:
       namespace: milo-system
     - name: notes-viewer
       namespace: milo-system
-    - name: identity-machine-account-keys-viewer
+    - name: identity-service-account-keys-viewer
       namespace: milo-system
-    - name: iam-machine-accounts-viewer
+    - name: iam-service-accounts-viewer
       namespace: milo-system


### PR DESCRIPTION
## Summary

- Updates assignable organization role configs (owner, editor, viewer) to reference renamed role names
- Updates README feature list

## Changes

| Old | New |
|-----|-----|
| `iam-machine-accounts-admin/editor/viewer` | `iam-service-accounts-admin/editor/viewer` |
| `identity-machine-account-keys-admin/editor/viewer` | `identity-service-account-keys-admin/editor/viewer` |

## Test plan

- [ ] Verify organization owners/editors/viewers can list and manage service accounts after deploy