### PR TITLE
feat: enable searchability for namespace field in contact resource index policy

### DIFF
--- a/config/services/search.miloapis.com/contact-resourceindexpolicy.yaml
+++ b/config/services/search.miloapis.com/contact-resourceindexpolicy.yaml
@@ -9,6 +9,8 @@ spec:
   fields:
   - path: .metadata.name
     searchable: true
+  - path: .metadata.namespace
+    searchable: true
   - path: .metadata.annotations["kubernetes.io/display-name"]
     searchable: true
   - path: .metadata.annotations["kubernetes.io/description"]


### PR DESCRIPTION
This PR updates the `contact-resouce-index-policy` to include the resource namespace.

Related to https://datum-inc.slack.com/archives/C0AKA02CNKT/p1778619856242009