### PR TITLE
feat: enable searchability for namespace field in domain and dnszone resource index policies

### DIFF
--- a/config/services/search.miloapis.com/dnszone-resourceindexpolicy.yaml
+++ b/config/services/search.miloapis.com/dnszone-resourceindexpolicy.yaml
@@ -9,6 +9,8 @@ spec:
   fields:
   - path: .metadata.name
     searchable: true
+  - path: .metadata.namespace
+    searchable: true
   - path: .metadata.annotations["kubernetes.io/display-name"]
     searchable: true
   - path: .metadata.annotations["kubernetes.io/description"]

--- a/config/services/search.miloapis.com/domain-resourceindexpolicy.yaml
+++ b/config/services/search.miloapis.com/domain-resourceindexpolicy.yaml
@@ -9,6 +9,8 @@ spec:
   fields:
   - path: .metadata.name
     searchable: true
+  - path: .metadata.namespace
+    searchable: true
   - path: .metadata.annotations["kubernetes.io/display-name"]
     searchable: true
   - path: .metadata.annotations["kubernetes.io/description"]


### PR DESCRIPTION
This PR updates the `domain-resource-index-policy` and `dnszone-resource-index-policy` to include the resource namespace, matching the precedent set in #226 for Contact.

## Why

The Search API only stores fields explicitly listed in a ResourceIndexPolicy's `fields[]`. Without `metadata.namespace` listed, the namespace is dropped from indexed documents and never returned in search responses.

In `datum-cloud/staff-portal`, the global Cmd+K search constructs detail links for Domains and DNSZones using URLs like `/customers/projects/{project}/domains/{namespace}/{name}`. Without namespace in the response, the frontend falls back to `default` and produces broken links — clicking a search result lands on a "resource not found" page when the resource actually lives in a non-default namespace.

This brings Domain and DNSZone in line with the Contact policy, which already exposes namespace.

## What

- `config/services/search.miloapis.com/domain-resourceindexpolicy.yaml` — adds `.metadata.namespace` to `fields[]`
- `config/services/search.miloapis.com/dnszone-resourceindexpolicy.yaml` — same

Both fields use `searchable: true`, matching the Contact policy.

Related: datum-cloud/staff-portal#464 (Search broken, sometimes)