### PR TITLE
feat(search): add HTTPProxy and ExportPolicy resource index policies

### DIFF
--- a/config/services/search.miloapis.com/exportpolicy-resourceindexpolicy.yaml
+++ b/config/services/search.miloapis.com/exportpolicy-resourceindexpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: search.miloapis.com/v1alpha1
+kind: ResourceIndexPolicy
+metadata:
+  name: exportpolicy-resource-index-policy
+spec:
+  conditions:
+  - expression: has(metadata.name)
+    name: has-name
+  fields:
+  - path: .metadata.name
+    searchable: true
+  - path: .metadata.namespace
+    searchable: true
+  - path: .metadata.annotations["kubernetes.io/display-name"]
+    searchable: true
+  - path: .metadata.annotations["kubernetes.io/description"]
+    searchable: true
+  - path: .spec.sources[*].name
+    searchable: true
+  - path: .spec.sinks[*].name
+    searchable: true
+  - path: .spec.sinks[*].endpoint
+    searchable: true
+  targetResource:
+    group: telemetry.miloapis.com
+    kind: ExportPolicy
+    version: v1alpha1

--- a/config/services/search.miloapis.com/httpproxy-resourceindexpolicy.yaml
+++ b/config/services/search.miloapis.com/httpproxy-resourceindexpolicy.yaml
@@ -1,0 +1,29 @@
+apiVersion: search.miloapis.com/v1alpha1
+kind: ResourceIndexPolicy
+metadata:
+  name: httpproxy-resource-index-policy
+spec:
+  conditions:
+  - expression: has(metadata.name)
+    name: has-name
+  fields:
+  - path: .metadata.name
+    searchable: true
+  - path: .metadata.namespace
+    searchable: true
+  - path: .metadata.annotations["kubernetes.io/display-name"]
+    searchable: true
+  - path: .metadata.annotations["kubernetes.io/description"]
+    searchable: true
+  - path: .spec.rules[*].hostnames[*]
+    searchable: true
+  - path: .spec.rules[*].name
+    searchable: true
+  - path: .spec.rules[*].backends[*].endpoint
+    searchable: true
+  - path: .status.addresses[*].value
+    searchable: true
+  targetResource:
+    group: networking.datumapis.com
+    kind: HTTPProxy
+    version: v1alpha

--- a/config/services/search.miloapis.com/kustomization.yaml
+++ b/config/services/search.miloapis.com/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
   - domain-resourceindexpolicy.yaml
   - dnszone-resourceindexpolicy.yaml
   - contact-resourceindexpolicy.yaml
+  - httpproxy-resourceindexpolicy.yaml
+  - exportpolicy-resourceindexpolicy.yaml
 
 # Use explicit sorting options so we can guarantee order in which resources are
 # applied.


### PR DESCRIPTION
## Problem

Cloud-portal global/project search currently covers only \`Domain\` and \`DNSZone\` for project-scoped resources. Users searching for HTTPProxies (HTTP edge routing) or ExportPolicies (telemetry sinks) get nothing because no \`ResourceIndexPolicy\` exists for those kinds, so milo-os/search has nothing to index.

## Fix

Adds two new \`ResourceIndexPolicy\` entries under \`config/services/search.miloapis.com/\`:

- \`httpproxy-resourceindexpolicy.yaml\` — \`networking.datumapis.com/v1alpha/HTTPProxy\` (sibling group to \`Domain\`)
- \`exportpolicy-resourceindexpolicy.yaml\` — \`telemetry.miloapis.com/v1alpha1/ExportPolicy\`

Each indexes \`metadata.name\`, \`metadata.namespace\`, the \`kubernetes.io/display-name\` and \`kubernetes.io/description\` annotations, plus 2-4 spec/status fields meaningful for search:

| Policy | Spec/status fields |
|---|---|
| HTTPProxy | \`spec.rules[*].hostnames[*]\`, \`spec.rules[*].name\`, \`spec.rules[*].backends[*].endpoint\`, \`status.addresses[*].value\` |
| ExportPolicy | \`spec.sources[*].name\`, \`spec.sinks[*].name\`, \`spec.sinks[*].endpoint\` |

The kustomization Component resource list is updated to include both files.

## Validation

- YAML structure matches the existing \`domain-resourceindexpolicy.yaml\` template
- GVKs cross-checked against the generated cloud-portal SDK (\`app/modules/control-plane/networking/schemas.gen.ts\` and \`telemetry/schemas.gen.ts\`)
- After merge + Flux sync, the policies will be \`Status.Ready=True\` with non-empty \`status.indexName\` once the resource-indexer (in milo-os/search) subscribes to the relevant NATS events for these kinds. If the indexer doesn't already cover them, the policy will be Ready but the index will stay empty — separate work to extend the indexer.

## Related

Cloud-portal companion change extends \`PROJECT_KINDS\` in \`search.constants.ts\` to include the two new kinds (separate PR on cloud-portal's \`search\` branch).