### PR TITLE
fix(search): comment out [*] wildcard paths until milo-os/search supports them

### DIFF
--- a/config/services/search.miloapis.com/exportpolicy-resourceindexpolicy.yaml
+++ b/config/services/search.miloapis.com/exportpolicy-resourceindexpolicy.yaml
@@ -15,12 +15,15 @@ spec:
     searchable: true
   - path: .metadata.annotations["kubernetes.io/description"]
     searchable: true
-  - path: .spec.sources[*].name
-    searchable: true
-  - path: .spec.sinks[*].name
-    searchable: true
-  - path: .spec.sinks[*].endpoint
-    searchable: true
+  # NOTE: [*] array-traversal syntax is not currently supported by the
+  # ResourceIndexPolicy validator in milo-os/search. The following paths are
+  # commented out until that lands. Tracked in milo-os/search#97.
+  # - path: .spec.sources[*].name
+  #   searchable: true
+  # - path: .spec.sinks[*].name
+  #   searchable: true
+  # - path: .spec.sinks[*].endpoint
+  #   searchable: true
   targetResource:
     group: telemetry.miloapis.com
     kind: ExportPolicy

--- a/config/services/search.miloapis.com/httpproxy-resourceindexpolicy.yaml
+++ b/config/services/search.miloapis.com/httpproxy-resourceindexpolicy.yaml
@@ -15,14 +15,17 @@ spec:
     searchable: true
   - path: .metadata.annotations["kubernetes.io/description"]
     searchable: true
-  - path: .spec.rules[*].hostnames[*]
-    searchable: true
-  - path: .spec.rules[*].name
-    searchable: true
-  - path: .spec.rules[*].backends[*].endpoint
-    searchable: true
-  - path: .status.addresses[*].value
-    searchable: true
+  # NOTE: [*] array-traversal syntax is not currently supported by the
+  # ResourceIndexPolicy validator in milo-os/search. The following paths are
+  # commented out until that lands. Tracked in milo-os/search#97.
+  # - path: .spec.rules[*].hostnames[*]
+  #   searchable: true
+  # - path: .spec.rules[*].name
+  #   searchable: true
+  # - path: .spec.rules[*].backends[*].endpoint
+  #   searchable: true
+  # - path: .status.addresses[*].value
+  #   searchable: true
   targetResource:
     group: networking.datumapis.com
     kind: HTTPProxy


### PR DESCRIPTION
## Problem

After PR #228 merged, Flux reported `ResourceIndexPolicy` validation failures on both new policies:

> ResourceIndexPolicy.search.miloapis.com "exportpolicy-resource-index-policy" is invalid:
> spec.fields[4].path: Invalid value: `.spec.sources[*].name`: invalid path syntax at: `[*].name`

milo-os/search's path validator currently only accepts numeric indices like `[0]`. The `[*]` array-traversal syntax we used isn't supported yet.

## Fix

Comment out the wildcard-using paths in both `httpproxy-resourceindexpolicy.yaml` and `exportpolicy-resourceindexpolicy.yaml`. The remaining fields (name, namespace, display-name and description annotations) are accepted by the validator and keep the policies functional, just with reduced search coverage.

The commented-out lines are preserved verbatim in the YAML so they can be re-enabled with a single revert once milo-os/search adds `[*]` support.

| File | Active fields after this PR | Commented-out (pending support) |
|---|---|---|
| `httpproxy-resourceindexpolicy.yaml` | name, namespace, display-name, description | `.spec.rules[*].hostnames[*]`, `.spec.rules[*].name`, `.spec.rules[*].backends[*].endpoint`, `.status.addresses[*].value` |
| `exportpolicy-resourceindexpolicy.yaml` | name, namespace, display-name, description | `.spec.sources[*].name`, `.spec.sinks[*].name`, `.spec.sinks[*].endpoint` |

## Tracking

- milo-os/search#97 — enhancement request for `[*]` wildcard support in `ResourceIndexPolicy` field paths

## Validation

The remaining 4 fields per policy are scalar paths matching the existing `domain-resourceindexpolicy.yaml` template, which validates and reconciles cleanly on staging.