### PR TITLE
feat(search): add display fields to Domain ResourceIndexPolicy

### DIFF
--- a/config/services/search.miloapis.com/domain-resourceindexpolicy.yaml
+++ b/config/services/search.miloapis.com/domain-resourceindexpolicy.yaml
@@ -11,12 +11,27 @@ spec:
     searchable: true
   - path: .metadata.namespace
     searchable: true
+  - path: .metadata.creationTimestamp
+    searchable: false
   - path: .metadata.annotations["kubernetes.io/display-name"]
     searchable: true
   - path: .metadata.annotations["kubernetes.io/description"]
     searchable: true
   - path: .spec.domainName
     searchable: true
+  - path: .status.registration.expiresAt
+    searchable: false
+  - path: .status.registration.registrar.name
+    searchable: false
+  # NOTE: [*] array-traversal syntax is not currently supported by the
+  # ResourceIndexPolicy validator in milo-os/search. The following paths are
+  # commented out until that lands. Tracked in milo-os/search#97.
+  # - path: .status.nameservers[*].hostname
+  #   searchable: false
+  # - path: .status.conditions[*].type
+  #   searchable: false
+  # - path: .status.conditions[*].status
+  #   searchable: false
   targetResource:
     group: networking.datumapis.com
     kind: Domain


### PR DESCRIPTION
## Summary

Extends the Domain `ResourceIndexPolicy` so the search index stores the fields needed to render a list page row without a second lookup per row.

New stored-only fields:
- `.metadata.creationTimestamp` — Created column
- `.status.registration.expiresAt` — Expiration column
- `.status.registration.registrar.name` — Registrar column

All marked `searchable: false` — they're display-only, not queryable.

## Why

[staff-portal#326](https://github.com/datum-cloud/staff-portal/issues/326) adds a global "Domains" view that lists every domain across all projects via the search API. Without these fields the registrar / expiration / created columns come back empty.

Same shape as #227 (which added `metadata.namespace` for the Cmd+K detail-link fix).

## Out of scope

Array-valued status fields (`nameservers`, `conditions`) need `[*]` traversal which the validator doesn't support yet (milo-os/search#97). Left commented out with a note, matching the pattern used in `httpproxy-resourceindexpolicy.yaml` and `exportpolicy-resourceindexpolicy.yaml` after #230.

## Test plan

- [ ] Policy reconciles cleanly after merge (no validator errors)
- [ ] Search API returns the new fields for Domain results
- [ ] staff-portal global Domains list renders registrar / expiration / created columns