### PR TITLE
feat(iam): add billing roles to assignable organization roles

### DIFF
--- a/config/assignable-organization-roles/roles/datum-cloud-editor.yaml
+++ b/config/assignable-organization-roles/roles/datum-cloud-editor.yaml
@@ -30,3 +30,5 @@ spec:
       namespace: milo-system
     - name: iam-service-accounts-editor
       namespace: milo-system
+    - name: billing.miloapis.com-admin
+      namespace: milo-system

--- a/config/assignable-organization-roles/roles/datum-cloud-owner.yaml
+++ b/config/assignable-organization-roles/roles/datum-cloud-owner.yaml
@@ -34,3 +34,5 @@ spec:
       namespace: milo-system
     - name: iam-service-accounts-admin
       namespace: milo-system
+    - name: billing.miloapis.com-admin
+      namespace: milo-system

--- a/config/assignable-organization-roles/roles/datum-cloud-viewer.yaml
+++ b/config/assignable-organization-roles/roles/datum-cloud-viewer.yaml
@@ -32,3 +32,5 @@ spec:
       namespace: milo-system
     - name: iam-service-accounts-viewer
       namespace: milo-system
+    - name: billing.miloapis.com-viewer
+      namespace: milo-system


### PR DESCRIPTION
## Summary

- Owner and Editor roles now include `billing.miloapis.com-admin`
- Viewer role now includes `billing.miloapis.com-viewer`

## Why

Creating a BillingAccount from the cloud portal fails with:

```
User "kwilliams@datum.net" cannot create resource "billingaccounts" in API group
"billing.miloapis.com" in the namespace "organization-personal-org-efb26a2b"
```

Organization members have no access to billing resources through their org-level role. The billing IAM roles (`billing.miloapis.com-admin` / `-viewer`) are already deployed and registered with Milo — `infra/apps/billing-system/base/milo-control-plane.yaml` applies `billing/config/components/iam` into `milo-system` — but were never wired into the assignable organization roles.

`billing.miloapis.com-admin` grants `billingaccounts.{create,update,patch,delete}` + the `billingaccountbindings` equivalents (and inherits `-viewer`); `billing.miloapis.com-viewer` grants `{list,get,watch}`.

Exactly mirrors the compute-roles wiring in #233.

## ⚠️ Decision for reviewers: should Editor get billing admin?

This follows #233's precedent (Owner **and** Editor get the resource admin role). But BillingAccounts tie to payment, so you may prefer **Owner-only** for `-admin` and give Editor `-viewer`. Easy to change — drop the editor entry. Flagging because billing is more sensitive than compute.

## Rollout

Like #233, this config publishes as an OCI bundle consumed by `datum-cloud/infra`. If you want to validate in staging ahead of the bundle, a staging-only patch in infra can apply it first.

## Verification after deploy

The original portal action (create BillingAccount as an org owner) should succeed; the authz denial should disappear.