### PR TITLE
feat(quota): add display name, description, and owner to project/dns registrations

### DIFF
--- a/config/services/dns.networking.miloapis.com/quota/registrations/dnsrecordset-registration.yaml
+++ b/config/services/dns.networking.miloapis.com/quota/registrations/dnsrecordset-registration.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app.kubernetes.io/name: datum
     app.kubernetes.io/component: quota-system
+    services.miloapis.com/owner: dns.networking.miloapis.com
+  annotations:
+    kubernetes.io/display-name: "DNS Record Sets"
+    kubernetes.io/description: "Maximum number of DNS record sets that can be created within a project"
 spec:
   # Project is the consumer of DNS record set quota
   consumerType:

--- a/config/services/dns.networking.miloapis.com/quota/registrations/dnszone-registration.yaml
+++ b/config/services/dns.networking.miloapis.com/quota/registrations/dnszone-registration.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app.kubernetes.io/name: datum
     app.kubernetes.io/component: quota-system
+    services.miloapis.com/owner: dns.networking.miloapis.com
+  annotations:
+    kubernetes.io/display-name: "DNS Zones"
+    kubernetes.io/description: "Maximum number of DNS zones that can be created within a project"
 spec:
   # Project is the consumer of DNS zone quota
   consumerType:

--- a/config/services/resourcemanager.miloapis.com/quota/registrations/project-registration.yaml
+++ b/config/services/resourcemanager.miloapis.com/quota/registrations/project-registration.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app.kubernetes.io/name: datum
     app.kubernetes.io/component: quota-system
+    services.miloapis.com/owner: resourcemanager.miloapis.com
+  annotations:
+    kubernetes.io/display-name: "Projects"
+    kubernetes.io/description: "Maximum number of projects that can be created within an organization"
 spec:
   # Organization is the consumer of project quota
   consumerType:


### PR DESCRIPTION
Part of datum-cloud/enhancements#735. Adopts the milo quota display metadata convention (`milo-os/milo` → `docs/architecture/quota-display.md`) for datum's quota registrations.

Adds to each `ResourceRegistration` (metadata-only, spec unchanged):

| Registration | `services.miloapis.com/owner` | display-name |
|---|---|---|
| projects-per-organization | resourcemanager.miloapis.com | Projects |
| dnszones-per-project | dns.networking.miloapis.com | DNS Zones |
| dnsrecordsets-per-project | dns.networking.miloapis.com | DNS Record Sets |

Plus `kubernetes.io/display-name` + `kubernetes.io/description` annotations.
