### PR TITLE
feat: grant org owners IPAM admin access

### DIFF
--- a/config/assignable-organization-roles/roles/datum-cloud-owner.yaml
+++ b/config/assignable-organization-roles/roles/datum-cloud-owner.yaml
@@ -36,3 +36,5 @@ spec:
       namespace: milo-system
     - name: billing.miloapis.com-admin
       namespace: milo-system
+    - name: ipam.miloapis.com-admin
+      namespace: milo-system


### PR DESCRIPTION
## What

Adds `ipam.miloapis.com-admin` to the datum-cloud **owner** assignable organization role, so organization owners can fully manage their IP address space — pools, prefixes, and allocations — within their own org's scope.

## Why here

The datum-cloud owner/editor/viewer roles are defined here and published in the `assignable-organization-roles` bundle that every environment consumes. Service grants like networking, DNS, telemetry, and billing already live in this role's `inheritedRoles`; the IPAM grant belongs alongside them, not as an environment-specific patch layered on top of the bundle in the infra repo. Defining it at the source means it flows to every environment through the normal release, with no per-overlay duplication.

## Scope

- Owner role only (mirrors admin grants for the other services).
- Reference by name/namespace; the `ipam.miloapis.com-admin` role is provided by the IPAM service. Read/write of IPAM resources stays scoped to the owner's own organization.

Companion change: the IPAM production deployment in datum-cloud/infra#2976, which no longer carries this grant.