### PR TITLE
feat(iam): grant service-entitlement access across owner, editor, and viewer roles

### DIFF
--- a/config/assignable-organization-roles/roles/datum-cloud-owner.yaml
+++ b/config/assignable-organization-roles/roles/datum-cloud-owner.yaml
@@ -38,3 +38,5 @@ spec:
       namespace: milo-system
     - name: ipam.miloapis.com-admin
       namespace: milo-system
+    - name: services.miloapis.com-entitlement-admin
+      namespace: milo-system

--- a/config/assignable-organization-roles/roles/datum-cloud-viewer.yaml
+++ b/config/assignable-organization-roles/roles/datum-cloud-viewer.yaml
@@ -34,3 +34,5 @@ spec:
       namespace: milo-system
     - name: billing.miloapis.com-viewer
       namespace: milo-system
+    - name: services.miloapis.com-entitlement-viewer
+      namespace: milo-system


### PR DESCRIPTION
## Impact

Running the IPAM CLI fails for organization members at every access level. Any `datumctl ipam` command aborts immediately:

```
Error: could not check IPAM service entitlement for project "…":
serviceentitlements.services.miloapis.com is forbidden: User "…" cannot list
resource "serviceentitlements" in API group "services.miloapis.com" at the cluster scope
```

Every service plugin runs an entitlement preflight — it lists the project's `ServiceEntitlement`s to confirm the service is enabled, and enabling a service creates one. None of the Datum Cloud org roles had access to the service-entitlement resources that gate services, so members couldn't check or request entitlement for the services they otherwise manage.

## Change

Grant service-entitlement access at the level appropriate to each role, reusing the roles the services layer already publishes:

- **Owner** → inherits `services.miloapis.com-entitlement-admin`: `list`/`get`/`watch` plus `create`/`update`/`delete`, so owners can check status and enable services from the CLI.
- **Viewer** → inherits `services.miloapis.com-entitlement-viewer`: `list`/`get`/`watch`, enough for read-only `datumctl ipam` commands to pass the preflight.
- **Editor** → covered automatically; it already inherits the Viewer role.

This matches the roles' all-inheritance composition and sits alongside the existing `ipam.miloapis.com-admin` grant it complements. `kustomize build` renders cleanly.

## Related work

- milo-os/ipam#43 — governs IPAM resources through Milo IAM (the `ipam.miloapis.com-admin` grant this pairs with).
- The IPAM CLI plugin's entitlement preflight is what surfaces this gap (milo-os/ipam#36, #65).