### PR TITLE
feat: Add onboarding IAM roles to assignable org roles

### DIFF
--- a/config/assignable-organization-roles/roles/datum-cloud-editor.yaml
+++ b/config/assignable-organization-roles/roles/datum-cloud-editor.yaml
@@ -32,3 +32,5 @@ spec:
       namespace: milo-system
     - name: billing.miloapis.com-admin
       namespace: milo-system
+    - name: compute.datumapis.com-admin
+      namespace: milo-system

--- a/config/assignable-organization-roles/roles/datum-cloud-owner.yaml
+++ b/config/assignable-organization-roles/roles/datum-cloud-owner.yaml
@@ -40,3 +40,9 @@ spec:
       namespace: milo-system
     - name: services.miloapis.com-entitlement-admin
       namespace: milo-system
+    - name: compute.datumapis.com-admin
+      namespace: milo-system
+    - name: networking.datumapis.com-locationbinding-viewer
+      namespace: milo-system
+    - name: stripe.billing.miloapis.com-stripe-payment-method-viewer
+      namespace: milo-system

--- a/config/assignable-organization-roles/roles/datum-cloud-viewer.yaml
+++ b/config/assignable-organization-roles/roles/datum-cloud-viewer.yaml
@@ -36,3 +36,7 @@ spec:
       namespace: milo-system
     - name: services.miloapis.com-entitlement-viewer
       namespace: milo-system
+    - name: compute.datumapis.com-viewer
+      namespace: milo-system
+    - name: networking.datumapis.com-location-viewer
+      namespace: milo-system


### PR DESCRIPTION
## Summary

Unified-organization onboarding needs owner/editor/viewer to inherit compute, networking LocationBinding, and Stripe payment-method roles. Those were being appended via patches in `datum-cloud/infra`, but assignable organization roles belong in this repo.

This adds the missing `inheritedRoles` entries to the `datum-cloud` owner, editor, and viewer Role definitions. Infra can drop the corresponding patches once this ships in the datum OCI bundle.

## Test plan

- [x] Diff owner/editor/viewer Role YAMLs
- [ ] After OCI publish, confirm Flux reconcile of `assignable-organization-roles` picks up the new inherited roles in staging
- [ ] Create a test org and verify owner can manage compute and read StripePaymentMethod status
- [ ] Drop infra patches in datum-cloud/infra#3284 after this lands

Related to datum-cloud/infra#3284