### PR TITLE
feat: Register Workload with the search index

### DIFF
--- a/config/services/search.miloapis.com/kustomization.yaml
+++ b/config/services/search.miloapis.com/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - contact-resourceindexpolicy.yaml
   - httpproxy-resourceindexpolicy.yaml
   - exportpolicy-resourceindexpolicy.yaml
+  - workload-resourceindexpolicy.yaml
 
 # Use explicit sorting options so we can guarantee order in which resources are
 # applied.

--- a/config/services/search.miloapis.com/workload-resourceindexpolicy.yaml
+++ b/config/services/search.miloapis.com/workload-resourceindexpolicy.yaml
@@ -1,0 +1,32 @@
+apiVersion: search.miloapis.com/v1alpha1
+kind: ResourceIndexPolicy
+metadata:
+  name: workload-resource-index-policy
+spec:
+  conditions:
+  - expression: has(metadata.name)
+    name: has-name
+  fields:
+  - path: .metadata.name
+    searchable: true
+  - path: .metadata.namespace
+    searchable: true
+  - path: .metadata.annotations["kubernetes.io/display-name"]
+    searchable: true
+  - path: .metadata.annotations["kubernetes.io/description"]
+    searchable: true
+  # NOTE: [*] array-traversal syntax is not currently supported by the
+  # ResourceIndexPolicy validator in milo-os/search (milo-os/search#97), so
+  # per-placement region/health (.spec.placements[*], .status.conditions[*])
+  # and container image (.spec.template.spec.containers[*].image) can't be
+  # indexed yet — only the scalar replica counters below are.
+  - path: .status.replicas
+    searchable: true
+  - path: .status.readyReplicas
+    searchable: true
+  - path: .status.desiredReplicas
+    searchable: true
+  targetResource:
+    group: compute.datumapis.com
+    kind: Workload
+    version: v1alpha


### PR DESCRIPTION
## Summary

A new staff-facing Workloads view needs to list compute workloads across every project on the platform, but Workload has no cluster-scoped List verb of its own — it's a per-project-control-plane CRD, so there's no single endpoint to query for "every workload everywhere."

Milo's search index (`search.miloapis.com`) already solves exactly this problem for other kinds (Domain, DNSZone, HTTPProxy, ...) via a config-only `ResourceIndexPolicy` — no search-service code changes required, since the indexer is fully generic. This registers `Workload` (`compute.datumapis.com`) the same way, following the `httpproxy`/`dnszone` policies in this directory as templates.

Only scalar fields are indexed for now (name, namespace, display annotations, replica counts). Per-placement region/health and container image live inside arrays (`spec.placements[*]`, `status.conditions[*]`), which the `ResourceIndexPolicy` validator doesn't support indexing yet ([milo-os/search#97](https://github.com/milo-os/search/issues/97)).

## Test plan

- [ ] `kustomize build config/services/search.miloapis.com` builds cleanly with the new policy included
- [ ] Once reconciled, `kubectl get resourceindexpolicy workload-resource-index-policy` shows a healthy status
- [ ] A blank-query `ResourceSearchQuery` against `search.miloapis.com` targeting `compute.datumapis.com/Workload` returns rows for at least one project with existing workloads