### PR TITLE
feat(iam): deny writes from users with unverified email

### DIFF
--- a/config/services/iam.miloapis.com/validation/kustomization.yaml
+++ b/config/services/iam.miloapis.com/validation/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Component
 
 resources:
   - approved-user-policy.yaml
+  - unverified-email-policy.yaml

--- a/config/services/iam.miloapis.com/validation/unverified-email-policy.yaml
+++ b/config/services/iam.miloapis.com/validation/unverified-email-policy.yaml
@@ -29,7 +29,6 @@ spec:
     #   whether to render an affordance at all. Denying the review would make an
     #   unverified account look like it lost access, rather than being asked to
     #   verify.
-    #   system:masters — matches milo's plugin/projectsuspension convention.
     #   deletionTimestamp — removing a finalizer is a plain UPDATE, so without
     #   this any finalizer-bearing resource owned by an unverified user would
     #   stick in Terminating. oldObject is null on CREATE, hence the guard.
@@ -38,7 +37,6 @@ spec:
         (!('iam.miloapis.com/emailVerified' in request.userInfo.extra)) ||
         (request.userInfo.extra['iam.miloapis.com/emailVerified'][0] == 'true') ||
         (request.resource.group == 'authorization.k8s.io') ||
-        ('system:masters' in request.userInfo.groups) ||
         (oldObject != null && has(oldObject.metadata.deletionTimestamp))
       message: "Email address is not verified. Verify your email address before creating or modifying resources."
       reason: Forbidden

--- a/config/services/iam.miloapis.com/validation/unverified-email-policy.yaml
+++ b/config/services/iam.miloapis.com/validation/unverified-email-policy.yaml
@@ -41,6 +41,12 @@ spec:
     #   the write would make an unverified account look like it had lost access
     #   entirely, instead of being asked to verify.
     #
+    #   system:masters — milo's convention, matching plugin/projectsuspension.
+    #   Note this is a project choice, not a Kubernetes guarantee: system:masters
+    #   bypasses authorization but admission still runs for it. Present here so
+    #   this policy and the equivalent milo plugin cannot disagree; if one grows
+    #   a carve-out, the other needs it too.
+    #
     #   Objects already being deleted — removing a finalizer is a plain UPDATE.
     #   Without this, any resource with a finalizer owned by an unverified user
     #   would be stuck Terminating forever. oldObject is null on CREATE, hence
@@ -50,6 +56,7 @@ spec:
         (!('iam.miloapis.com/emailVerified' in request.userInfo.extra)) ||
         (request.userInfo.extra['iam.miloapis.com/emailVerified'][0] == 'true') ||
         (request.resource.group == 'authorization.k8s.io') ||
+        ('system:masters' in request.userInfo.groups) ||
         (oldObject != null && has(oldObject.metadata.deletionTimestamp))
       message: "Email address is not verified. Verify your email address before creating or modifying resources."
       reason: Forbidden

--- a/config/services/iam.miloapis.com/validation/unverified-email-policy.yaml
+++ b/config/services/iam.miloapis.com/validation/unverified-email-policy.yaml
@@ -1,25 +1,16 @@
 # Denies writes from end users who have not verified their email address.
 #
 # The signal is stamped onto the authenticated identity by zitadel-provider's
-# TokenReview webhook, alongside iam.miloapis.com/registrationApproval. Reading
-# it from userInfo.extra is what makes this expressible as a policy at all: a
-# rule that had to look up the caller's User resource cannot do so from CEL, and
-# the alternative was a compiled-in milo admission plugin carrying an informer
-# cache of ServiceAccount UIDs.
+# TokenReview webhook, alongside iam.miloapis.com/registrationApproval.
 #
-# ABSENCE ADMITS, and that is a contract with the producer, not an oversight.
-# Machine identities carry no email claim, so they get no key and pass here.
-# zitadel-provider guarantees the converse: a human ALWAYS carries the key, set
-# to "true" or "false", never omitted. If that guarantee ever breaks, this
-# policy fails open for humans — so the two sides have to change together.
+# ABSENCE ADMITS. Machine identities carry no email claim and so carry no key.
+# zitadel-provider guarantees a human always carries it, set to "true" or
+# "false" and never omitted; if that breaks, this fails open for humans. The
+# two sides have to change together.
 #
-# It is also why this file is safe to deploy before the producer ships: until
-# zitadel-provider sets the key, nobody carries it and nothing is denied.
-#
-# CREATE and UPDATE only. Reads never route through admission, so this cannot
-# gate them however it is written — restricting what an unverified user can SEE
-# is the portal's job. DELETE is likewise unlisted, so an unverified user can
-# still clean up after themselves.
+# CREATE and UPDATE only. Reads never route through admission, so restricting
+# what an unverified user can see is the portal's job. DELETE is left off so an
+# unverified user can still clean up after themselves.
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
@@ -33,24 +24,15 @@ spec:
         operations: ["CREATE", "UPDATE"]
         resources: ["*"]
   validations:
-    # Clause order is the reading order: admit the identities this policy has no
-    # opinion about, then admit verified humans, then the two carve-outs.
-    #
+    # Carve-outs, in clause order:
     #   authorization.k8s.io — clients create a SelfSubjectAccessReview to decide
-    #   whether to render an affordance at all. Denying the review rather than
-    #   the write would make an unverified account look like it had lost access
-    #   entirely, instead of being asked to verify.
-    #
-    #   system:masters — milo's convention, matching plugin/projectsuspension.
-    #   Note this is a project choice, not a Kubernetes guarantee: system:masters
-    #   bypasses authorization but admission still runs for it. Present here so
-    #   this policy and the equivalent milo plugin cannot disagree; if one grows
-    #   a carve-out, the other needs it too.
-    #
-    #   Objects already being deleted — removing a finalizer is a plain UPDATE.
-    #   Without this, any resource with a finalizer owned by an unverified user
-    #   would be stuck Terminating forever. oldObject is null on CREATE, hence
-    #   the null guard.
+    #   whether to render an affordance at all. Denying the review would make an
+    #   unverified account look like it lost access, rather than being asked to
+    #   verify.
+    #   system:masters — matches milo's plugin/projectsuspension convention.
+    #   deletionTimestamp — removing a finalizer is a plain UPDATE, so without
+    #   this any finalizer-bearing resource owned by an unverified user would
+    #   stick in Terminating. oldObject is null on CREATE, hence the guard.
     - expression: >-
         (!has(request.userInfo.extra)) ||
         (!('iam.miloapis.com/emailVerified' in request.userInfo.extra)) ||
@@ -61,16 +43,12 @@ spec:
       message: "Email address is not verified. Verify your email address before creating or modifying resources."
       reason: Forbidden
 ---
-# Ships as Warn + Audit, NOT Deny.
+# Ships as Warn + Audit, not Deny: no identity carried this key before the
+# producer shipped, so Deny would gate every human the moment zitadel-provider
+# rolls. Read apiserver_validating_admission_policy_check_total
+# {enforcement_action="audit"} before promoting to [Deny].
 #
-# No identity carried this key before the producer shipped, so going straight to
-# Deny would gate every human the moment zitadel-provider rolls. Audit mode puts
-# the real number in apiserver_validating_admission_policy_check_total
-# {enforcement_action="audit"} first — which is the count that decides whether
-# Deny is safe, and it costs no backfill job to obtain.
-#
-# Promote to [Deny] only after reading that counter, and enable the portal-side
-# gate before this one. Disable in the reverse order.
+# Enable the portal-side gate before this one; disable in the reverse order.
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:

--- a/config/services/iam.miloapis.com/validation/unverified-email-policy.yaml
+++ b/config/services/iam.miloapis.com/validation/unverified-email-policy.yaml
@@ -1,0 +1,73 @@
+# Denies writes from end users who have not verified their email address.
+#
+# The signal is stamped onto the authenticated identity by zitadel-provider's
+# TokenReview webhook, alongside iam.miloapis.com/registrationApproval. Reading
+# it from userInfo.extra is what makes this expressible as a policy at all: a
+# rule that had to look up the caller's User resource cannot do so from CEL, and
+# the alternative was a compiled-in milo admission plugin carrying an informer
+# cache of ServiceAccount UIDs.
+#
+# ABSENCE ADMITS, and that is a contract with the producer, not an oversight.
+# Machine identities carry no email claim, so they get no key and pass here.
+# zitadel-provider guarantees the converse: a human ALWAYS carries the key, set
+# to "true" or "false", never omitted. If that guarantee ever breaks, this
+# policy fails open for humans — so the two sides have to change together.
+#
+# It is also why this file is safe to deploy before the producer ships: until
+# zitadel-provider sets the key, nobody carries it and nothing is denied.
+#
+# CREATE and UPDATE only. Reads never route through admission, so this cannot
+# gate them however it is written — restricting what an unverified user can SEE
+# is the portal's job. DELETE is likewise unlisted, so an unverified user can
+# still clean up after themselves.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "deny-unverified-email"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["*"]
+        apiVersions: ["*"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["*"]
+  validations:
+    # Clause order is the reading order: admit the identities this policy has no
+    # opinion about, then admit verified humans, then the two carve-outs.
+    #
+    #   authorization.k8s.io — clients create a SelfSubjectAccessReview to decide
+    #   whether to render an affordance at all. Denying the review rather than
+    #   the write would make an unverified account look like it had lost access
+    #   entirely, instead of being asked to verify.
+    #
+    #   Objects already being deleted — removing a finalizer is a plain UPDATE.
+    #   Without this, any resource with a finalizer owned by an unverified user
+    #   would be stuck Terminating forever. oldObject is null on CREATE, hence
+    #   the null guard.
+    - expression: >-
+        (!has(request.userInfo.extra)) ||
+        (!('iam.miloapis.com/emailVerified' in request.userInfo.extra)) ||
+        (request.userInfo.extra['iam.miloapis.com/emailVerified'][0] == 'true') ||
+        (request.resource.group == 'authorization.k8s.io') ||
+        (oldObject != null && has(oldObject.metadata.deletionTimestamp))
+      message: "Email address is not verified. Verify your email address before creating or modifying resources."
+      reason: Forbidden
+---
+# Ships as Warn + Audit, NOT Deny.
+#
+# No identity carried this key before the producer shipped, so going straight to
+# Deny would gate every human the moment zitadel-provider rolls. Audit mode puts
+# the real number in apiserver_validating_admission_policy_check_total
+# {enforcement_action="audit"} first — which is the count that decides whether
+# Deny is safe, and it costs no backfill job to obtain.
+#
+# Promote to [Deny] only after reading that counter, and enable the portal-side
+# gate before this one. Disable in the reverse order.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "deny-unverified-email"
+spec:
+  policyName: "deny-unverified-email"
+  validationActions: [Warn, Audit]

--- a/config/services/iam.miloapis.com/validation/unverified-email-policy.yaml
+++ b/config/services/iam.miloapis.com/validation/unverified-email-policy.yaml
@@ -32,11 +32,15 @@ spec:
     #   deletionTimestamp — removing a finalizer is a plain UPDATE, so without
     #   this any finalizer-bearing resource owned by an unverified user would
     #   stick in Terminating. oldObject is null on CREATE, hence the guard.
+    # Deliberately does not start with "(". Milo's chainsaw test applies a copy
+    # of this policy, and chainsaw evaluates any value that opens with "(" and
+    # closes with ")" as a JMESPath expression rather than passing it through.
+    # Kustomize does not care either way; keeping the two identical does.
     - expression: >-
-        (!has(request.userInfo.extra)) ||
-        (!('iam.miloapis.com/emailVerified' in request.userInfo.extra)) ||
-        (request.userInfo.extra['iam.miloapis.com/emailVerified'][0] == 'true') ||
-        (request.resource.group == 'authorization.k8s.io') ||
+        !has(request.userInfo.extra) ||
+        !('iam.miloapis.com/emailVerified' in request.userInfo.extra) ||
+        request.userInfo.extra['iam.miloapis.com/emailVerified'][0] == 'true' ||
+        request.resource.group == 'authorization.k8s.io' ||
         (oldObject != null && has(oldObject.metadata.deletionTimestamp))
       message: "Email address is not verified. Verify your email address before creating or modifying resources."
       reason: Forbidden


### PR DESCRIPTION
## What's the current problem?

Nothing stops an account that never confirmed its email address from creating resources. The portal can redirect someone to "check your inbox", but anyone holding a token can call the API directly.

## How are we solving it?

A `ValidatingAdmissionPolicy` denying CREATE and UPDATE from identities carrying `iam.miloapis.com/emailVerified: "false"`, modelled on `deny-unapproved-user` in this same directory. The key is stamped by [zitadel-provider#127](https://github.com/milo-os/zitadel-provider/pull/127) alongside `registrationApproval`.

**Ships `[Warn, Audit]`, not `[Deny]`.** No identity carried this key before, so going straight to Deny would gate every human the moment the producer rolls. Audit puts the real number in `apiserver_validating_admission_policy_check_total{enforcement_action="audit"}` first — the count that decides whether Deny is safe, and it needs no backfill job to obtain.

**Safe to merge before the producer ships:** absence of the key admits, so until zitadel-provider rolls, nothing is denied.

## Why are we solving it?

Part of the passkey program — [enhancements#738](https://github.com/datum-cloud/enhancements/issues/738). An unverified account shouldn't be able to act on the platform.

A policy rather than a compiled-in milo plugin, because the signal travels on the identity. A rule that had to look up the caller's `User` resource couldn't do so from CEL at all — it would need an admission plugin holding an informer cache, which is what this replaces.

## Two things worth knowing

**Absence admitting is a contract, not an oversight.** Machine identities carry no `email` claim, so they get no key and pass. zitadel-provider guarantees the converse and tests it: a human *always* carries the key, `"true"` or `"false"`, never omitted. If that breaks, this fails open for humans — the two sides change together.

**Three carve-outs.** `authorization.k8s.io`, because clients create a `SelfSubjectAccessReview` to decide whether to render an affordance at all, and denying the review would make an unverified account look like it lost access entirely. `system:masters`, matching the convention in milo's `projectsuspension` admission plugin. And objects already being deleted, because finalizer removal is a plain UPDATE — without it, finalizer-bearing resources would stick in Terminating forever.

## Scope

**This is the only enforcement point.** A compiled-in milo plugin expressing the same rule was carried in parallel while the question below was open; it has since been dropped, so nothing here duplicates anything.

Project control planes are not covered. A policy reaches the control planes it is deployed to, and milo's CRD bootstrap seeds CRDs but not policies — `deny-unapproved-user` has the same footprint today. Milo owns no `ProjectControlPlane` controller either, only the CRD type, so how those apiservers are configured was never milo's to decide.

## Verification

`kustomize build config/services/iam.miloapis.com/` renders both policies and their bindings. The CEL is exercised by a chainsaw test in milo (`test/admission/email-verification-policy/`), which proves it compiles and doesn't error at evaluation — under `failurePolicy: Fail` that would deny every write.