### PR TITLE
feat: grant viewers the locations service

### DIFF
--- a/config/assignable-organization-roles/roles/datum-cloud-viewer.yaml
+++ b/config/assignable-organization-roles/roles/datum-cloud-viewer.yaml
@@ -40,3 +40,7 @@ spec:
       namespace: milo-system
     - name: networking.datumapis.com-location-viewer
       namespace: milo-system
+    # Locations moved to their own service. Both roles are listed while both
+    # groups are served; the network-services one goes when that group does.
+    - name: locations.miloapis.com-location-viewer
+      namespace: milo-system


### PR DESCRIPTION
Locations moved to their own service and API group. The viewer role still grants read on the network-services group alone, so a viewer reading the new group is refused.

Staging hides this. A patch there grants the new role through `project-viewer`, so it happens to work. Production carries no such patch, and a viewer would be refused the moment production reads locations from the locations service.

This grants the role where the customer-facing roles live, so both environments are covered by one definition rather than an environment patch.

Both roles are listed while both groups are served. The network-services one goes when that group does.

Related: [datum-cloud/infra#4386](https://github.com/datum-cloud/infra/pull/4386) declares production's locations, [datum-cloud/infra#4283](https://github.com/datum-cloud/infra/pull/4283) is the staging patch this supersedes.
